### PR TITLE
Fixed invalid pem file error handling

### DIFF
--- a/trcinit/initlib/vault-seed.go
+++ b/trcinit/initlib/vault-seed.go
@@ -455,7 +455,11 @@ func SeedVaultFromData(config *eUtils.DriverConfig, filepath string, fData []byt
 							}
 						}
 					} else {
-						eUtils.LogInfo(config, "Cert validation failure.  Cert will not be loaded."+certValidationErr.Error())
+						if certValidationErr == nil {
+							eUtils.LogInfo(config, "Cert validation failure. Cert will not be loaded.")
+						} else {
+							eUtils.LogInfo(config, "Cert validation failure.  Cert will not be loaded."+certValidationErr.Error())
+						}
 						delete(entry.data, "certData")
 						delete(entry.data, "certHost")
 						delete(entry.data, "certSourcePath")


### PR DESCRIPTION
vault-seed.go doesn't return an error when validating pem files and so a nil variable is accessed when displaying an error message. A null check was added to handle this and message is written that doesn't access this variable.