### PR TITLE
Fixed seed process

### DIFF
--- a/trcinit/initlib/vault-seed.go
+++ b/trcinit/initlib/vault-seed.go
@@ -236,7 +236,7 @@ func SeedVault(insecure bool,
 	if !seeded {
 		eUtils.LogInfo(config, "Environment is not valid - Environment: "+env)
 	} else {
-		eUtils.LogInfo(config, "Environment is not seeded - Environment: "+env)
+		eUtils.LogInfo(config, "Initialization complete for: "+env)
 	}
 	return nil
 }


### PR DESCRIPTION
seeded needed to be set to true, and the codespace where it does it never would get hit. Now it's being set to true after seeding vault