### PR TITLE
Merging Main into Plugin (#572)

### DIFF
--- a/azure-pipelines-legacy.yml
+++ b/azure-pipelines-legacy.yml
@@ -49,17 +49,17 @@ resources:
     type: github
     endpoint: trimble-oss
     name: trimble-oss/client-go
-    ref: refs/tags/v0.0.2
+    ref: refs/tags/v0.0.3
   - repository: cli-runtime
     type: github
     endpoint: trimble-oss
     name: trimble-oss/cli-runtime
-    ref: refs/tags/v0.0.5
+    ref: refs/tags/v0.0.6
   - repository: kubectl
     type: github
     endpoint: trimble-oss
     name: trimble-oss/kubectl
-    ref: refs/tags/v0.0.3
+    ref: refs/tags/v0.0.4
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -43,17 +43,17 @@ resources:
     type: github
     endpoint: trimble-oss
     name: trimble-oss/client-go
-    ref: refs/tags/v0.0.2
+    ref: refs/tags/v0.0.3
   - repository: cli-runtime
     type: github
     endpoint: trimble-oss
     name: trimble-oss/cli-runtime
-    ref: refs/tags/v0.0.5
+    ref: refs/tags/v0.0.6
   - repository: kubectl
     type: github
     endpoint: trimble-oss
     name: trimble-oss/kubectl
-    ref: refs/tags/v0.0.3
+    ref: refs/tags/v0.0.4
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path

--- a/azure-pipelines-plugin-develop.yml
+++ b/azure-pipelines-plugin-develop.yml
@@ -46,17 +46,17 @@ resources:
     type: github
     endpoint: trimble-oss
     name: trimble-oss/client-go
-    ref: refs/tags/v0.0.2
+    ref: refs/tags/v0.0.3
   - repository: cli-runtime
     type: github
     endpoint: trimble-oss
     name: trimble-oss/cli-runtime
-    ref: refs/tags/v0.0.5
+    ref: refs/tags/v0.0.6
   - repository: kubectl
     type: github
     endpoint: trimble-oss
     name: trimble-oss/kubectl
-    ref: refs/tags/v0.0.3
+    ref: refs/tags/v0.0.4
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path

--- a/azure-pipelines-plugin.yml
+++ b/azure-pipelines-plugin.yml
@@ -51,17 +51,17 @@ resources:
     type: github
     endpoint: trimble-oss
     name: trimble-oss/client-go
-    ref: refs/tags/v0.0.2
+    ref: refs/tags/v0.0.3
   - repository: cli-runtime
     type: github
     endpoint: trimble-oss
     name: trimble-oss/cli-runtime
-    ref: refs/tags/v0.0.5
+    ref: refs/tags/v0.0.6
   - repository: kubectl
     type: github
     endpoint: trimble-oss
     name: trimble-oss/kubectl
-    ref: refs/tags/v0.0.3
+    ref: refs/tags/v0.0.4
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,17 +49,17 @@ resources:
     type: github
     endpoint: trimble-oss
     name: trimble-oss/client-go
-    ref: refs/tags/v0.0.2
+    ref: refs/tags/v0.0.3
   - repository: cli-runtime
     type: github
     endpoint: trimble-oss
     name: trimble-oss/cli-runtime
-    ref: refs/tags/v0.0.5
+    ref: refs/tags/v0.0.6
   - repository: kubectl
     type: github
     endpoint: trimble-oss
     name: trimble-oss/kubectl
-    ref: refs/tags/v0.0.3
+    ref: refs/tags/v0.0.4
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path

--- a/go.mod
+++ b/go.mod
@@ -239,11 +239,11 @@ replace gioui.org v0.0.0-20220318070519-8833a6738a3b => github.com/mrjrieke/gio 
 
 replace github.com/fyne-io/glfw-js v0.0.0-20220120001248-ee7290d23504 => github.com/mrjrieke/glfw-js v0.0.0-20220409154018-95a896685cdb
 
-//replace k8s.io/client-go v0.26.1 => github.com/trimble-oss/client-go v0.0.2
+// replace k8s.io/client-go v0.26.1 => github.com/trimble-oss/client-go v0.0.3
 
-//replace k8s.io/cli-runtime v0.26.1 => github.com/trimble-oss/cli-runtime v0.0.5
+// replace k8s.io/cli-runtime v0.26.1 => github.com/trimble-oss/cli-runtime v0.0.6
 
-//replace k8s.io/kubectl v0.26.1 => github.com/trimble-oss/kubectl v0.0.3
+// replace k8s.io/kubectl v0.26.1 => github.com/trimble-oss/kubectl v0.0.4
 
 //Don't forget to update pipelines with the right version.
 

--- a/trcsh/kube/native/trccreate/create_configmap.go
+++ b/trcsh/kube/native/trccreate/create_configmap.go
@@ -1,0 +1,121 @@
+package trccreate
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+var utf8bom = []byte{0xEF, 0xBB, 0xBF}
+
+// validateNewConfigMap checks whether the keyname is valid
+// Note, the rules for ConfigMap keys are the exact same as the ones for SecretKeys.
+func validateNewConfigMap(configMap *corev1.ConfigMap, keyName string) error {
+	if errs := validation.IsConfigMapKey(keyName); len(errs) > 0 {
+		return fmt.Errorf("%q is not a valid key name for a ConfigMap: %s", keyName, strings.Join(errs, ","))
+	}
+	if _, exists := configMap.Data[keyName]; exists {
+		return fmt.Errorf("cannot add key %q, another key by that name already exists in Data for ConfigMap %q", keyName, configMap.Name)
+	}
+	if _, exists := configMap.BinaryData[keyName]; exists {
+		return fmt.Errorf("cannot add key %q, another key by that name already exists in BinaryData for ConfigMap %q", keyName, configMap.Name)
+	}
+
+	return nil
+}
+
+func addKeyFromLiteralToConfigMap(configMap *corev1.ConfigMap, keyName, data string) error {
+	err := validateNewConfigMap(configMap, keyName)
+	if err != nil {
+		return err
+	}
+	configMap.Data[keyName] = data
+
+	return nil
+}
+
+// Function from kubectl
+func processEnvFileLine(line []byte, filePath string,
+	currentLine int) (key, value string, err error) {
+
+	if !utf8.Valid(line) {
+		return ``, ``, fmt.Errorf("env file %s contains invalid utf8 bytes at line %d: %v",
+			filePath, currentLine+1, line)
+	}
+
+	// We trim UTF8 BOM from the first line of the file but no others
+	if currentLine == 0 {
+		line = bytes.TrimPrefix(line, utf8bom)
+	}
+
+	// trim the line from all leading whitespace first
+	line = bytes.TrimLeftFunc(line, unicode.IsSpace)
+
+	// If the line is empty or a comment, we return a blank key/value pair.
+	if len(line) == 0 || line[0] == '#' {
+		return ``, ``, nil
+	}
+
+	data := strings.SplitN(string(line), "=", 2)
+	key = data[0]
+	if errs := validation.IsEnvVarName(key); len(errs) != 0 {
+		return ``, ``, fmt.Errorf("%q is not a valid key name: %s", key, strings.Join(errs, ";"))
+	}
+
+	if len(data) == 2 {
+		value = data[1]
+	} else {
+		// No value (no `=` in the line) is a signal to obtain the value
+		// from the environment.
+		value = os.Getenv(key)
+	}
+	return
+}
+
+// AddFromEnvFile processes an env file allows a generic addTo to handle the
+// collection of key value pairs or returns an error.
+func AddFromMemEnvFile(filePath string, data []byte, addTo func(key, value string) error) error {
+
+	reader := bytes.NewReader(data)
+	scanner := bufio.NewScanner(reader)
+	currentLine := 0
+	for scanner.Scan() {
+		// Process the current line, retrieving a key/value pair if
+		// possible.
+		scannedBytes := scanner.Bytes()
+		key, value, err := processEnvFileLine(scannedBytes, filePath, currentLine)
+		if err != nil {
+			return err
+		}
+		currentLine++
+
+		if len(key) == 0 {
+			// no key means line was empty or a comment
+			continue
+		}
+
+		if err = addTo(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func HandleConfigMapFromEnvFileSource(configMap *corev1.ConfigMap, filePath string, data []byte) error {
+	err := AddFromMemEnvFile(filePath, data, func(key, value string) error {
+		return addKeyFromLiteralToConfigMap(configMap, key, value)
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
* Fixing deadlock.

* Handle case where sha256 do not match.

* Make db acquisition optional. (#517)



* Merging Develop into Main (#523)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

---------






* Simplify pipelines. (#527)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

---------





* Build improvements. (#528)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

* BuildSpeedTest#12

---------





* snyke every pipeline. (#529)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

* BuildSpeedTest#12

* BuildSpeedTest#14

---------





* Merging Main into Comprehensive (#526)

* Adding tightening.

* Adding tightening. (#488)



* Latest minor go release.

* Merging Main to Plugin (#489)

* Adding tightening.

* Adding tightening. (#488)



* Latest minor go release.

---------




* Fixing some other missing configs.

* Fix some broken paths.

* Some very minor cleanup.

* Fix deadlock.

* Don't take new carrier params during plugin deploys.

* Dropping uneccessary variable collection.

* Merging Develop into Main (#493)

* Some very minor cleanup.

* Fix deadlock.

* Don't take new carrier params during plugin deploys.

* Dropping uneccessary variable collection.

---------



* Merging Develop into Main (#493) (#494)

* Some very minor cleanup.

* Fix deadlock.

* Don't take new carrier params during plugin deploys.

* Dropping uneccessary variable collection.

---------



* Better handling of missing storage.

* Adding some logging.

* Lock incoming.

* Handle sparse data.

* Handle sparse data. (#498)

* Couple more nil checks.

* Provide an empty map when none provided.

* Fixing unexpected nil error.

* Handle vaddress as well.

* Merging Develop into Main (#501)

* Fixing unexpected nil error.

* Handle vaddress as well.

---------



* Merging Develop into Main (#501) (#502)

* Fixing unexpected nil error.

* Handle vaddress as well.

---------



* Default to vault.

* Merging Develop into Main (#503)

* Fixing unexpected nil error.

* Handle vaddress as well.

* Default to vault.

---------



* Merging Main into Plugin (#504)

* Merging Develop into Main (#501)

* Fixing unexpected nil error.

* Handle vaddress as well.

---------



* Merging Develop into Main (#503)

* Fixing unexpected nil error.

* Handle vaddress as well.

* Default to vault.

---------



---------



* Adding another data check.

* Handling potential corner cases.

* Don't update if expected tokens are incomplete.

* Simplify carrier flows.

* Refactor capauth to make it easier to support multiple environments.

* Refactor a little more to get us closer to a cap startup for multiple environments.

* Refactor a little more to get us closer to a cap startup for multiple environments. other parts.

* Fixing typo.

* Fix optional log namespace init failure.

* Fixing npe.

* Satisfy new func requirements.

* Fixing deadlock.

* Fixing deadlock. (#514)




* Handle case where sha256 do not match.

* Main (#516)

* Fixing deadlock.

* Handle case where sha256 do not match.

* Make db acquisition optional. (#517)



* Merging Main into Plugin (#518)

* Fixing deadlock.

* Handle case where sha256 do not match.

* Make db acquisition optional. (#517)



---------




* Merging Develop into Main (#523)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

---------






* Merging Main to Plugin (#525)

* Fixing deadlock.

* Handle case where sha256 do not match.

* Make db acquisition optional. (#517)



* Merging Develop into Main (#523)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

---------






---------






* Simplify pipelines. (#527)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

---------





* Build improvements. (#528)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

* BuildSpeedTest#12

---------





* snyke every pipeline. (#529)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

* BuildSpeedTest#12

* BuildSpeedTest#14

---------





---------






* Update carrier for better permissions. (#531)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

* BuildSpeedTest#12

* BuildSpeedTest#14

* Adding deployed for agent types

* Adding support for agent deploys

* Standardize chmod.

* Update for cleanup if unexpected conditions arise.

---------





* Exclude develop from plugin release builds. (#533)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

* BuildSpeedTest#12

* BuildSpeedTest#14

* Adding deployed for agent types

* Adding support for agent deploys

* Standardize chmod.

* Update for cleanup if unexpected conditions arise.

* Exclude plugin from this pipeline.

---------





* Change perms (#534)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

* BuildSpeedTest#12

* BuildSpeedTest#14

* Adding deployed for agent types

* Adding support for agent deploys

* Standardize chmod.

* Update for cleanup if unexpected conditions arise.

* Exclude plugin from this pipeline.

* Improve carrier logging.

* Removing unecessary extra bit.

* Simplify.

---------





* Try again. (#536)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...




* Changing pool

* Add init headless.

* Updating pool

* BuildSpeedTest#1

* BuildSpeedTest#2

* BuildSpeedTest#3

* BuildSpeedTest#4

* BuildSpeedTest#5

* BuildSpeedTest#6

* BuildSpeedTest#7

* BuildSpeedTest#8

* BuildSpeedTest#9

* BuildSpeedTest#10

* BuildSpeedTest#11

* Simplify all pipelines.

* Standardize display.

* BuildSpeedTest#12

* BuildSpeedTest#14

* Adding deployed for agent types

* Adding support for agent deploys

* Standardize chmod.

* Update for cleanup if unexpected conditions arise.

* Exclude plugin from this pipeline.

* Improve carrier logging.

* Removing unecessary extra bit.

* Simplify.

* Try to exclude other branch builds.

---------





* Merging Develop into Main (#538)

* Updating main.tf

* More changes

* Adding subresources

* Updating to ubuntu 20.04

* auto install tools.

* Updating to Ubuntu 20.04

* Adding update.

* Adding comment

* Rolling back because 20.04 is really unstable when used with terraform.

* Adding my notes for manual steps.

* Moving forward to 20.04 again...

* Updating ubuntu version to more stable version

* A couple small improvements.

* Fixing break.

* Make db acquisition optional.

* Bump golang.org/x/net from 0.5.0 to 0.7.0

Bumps [golang.org/x/net](https://github.com/golang/net) from 0.5.0 to 0.7.0.
- [Release notes](https://github.com/golang/net/releases)
- [Commits](https://github.com/golang/net/compare/v0.5.0...v0.7.0)

---
updated-dependencies:
- dependency-name: golang.org/x/net dependency-type: indirect ...



* Adding docker permissions

* Adding some more setup instructions.

* Adding couple more manual steps.

* Update for better local support.

* Fix and simplify pub.

* Simplify local development.

* Adding support for file args

* Adding support for file args

* Fixing race condition.

* Trckubeimport (#521)

* Adding subnet

* Checking in merged changes with help from COPS.

* Templatizing kube version

---------



* Feature/kubernetes deployment minimal (#522)

* Adding kube config parsing.

* Using something that's hopefully more useful to us.

* Fixing broken build.

* Refactor and cleanup.

* Remove accidental hardcoded env.

* Implement parsing of kubernetes lines.

* Handle dot relative pathing as well for config map.

* Update library versions and coding.

* Including support for comments

* Including support for comments

* Committing progress.

* Committing go mod changes.

* More changes.

* Update provider version.

* Checking in progress.

* More glue added.

* Get this compiling.

* Flush out required data structures.

* More mod cleanup.

* This gets applies at least parsing.

* Updating readme.

* Small cleanup.

* Update some links.

* Prepare for move.

* Prepare for move.

* Refactor code to preserve original structure as much as possible.

* Disable apply for now.

* Prune unecessary code and let apply deal with it.

* Adding vars to remove local vars

* Templatizing local vars

* Fix package naming.

* Checking in minimal implementation.

* Move to bleeding edge.

* Update to latest.

* Update to use trimble repo and tag.

* Update go mod.

* Commit setup.

* Adding memfilevisitor.

* Switch to full kubectl client.

* Switch to full kubectl client. pt 2

* Update for new code source.

* Change branch to path visitor.

* Change branch to path visitor.  checkout more repos.

* Updating for code dependencies.

* Updates to go.sum

* Internal projects need to be relative for now.

* Adding deploy auth to trcsh

* Fix logging.

* Adding error message for invalid deploys

---------



* Bump golang.org/x/image from 0.0.0-20220601225756-64ec528b34cd to 0.5.0 (#524)

Bumps [golang.org/x/image](https://github.com/golang/image) from 0.0.0-20220601225756-64ec528b34cd to 0.5.0.
- [Release notes](https://github.com/golang/image/releases)
- [Commits](https://github.com/golang/image/commits/v0.5.0)

---
updated-dependencies:
- dependency-name: golang.org/x/image dependency-type: indirect ...

…