### PR TITLE
Handle invalid accessors.

### DIFF
--- a/pkg/cli/trcinitbase/init.go
+++ b/pkg/cli/trcinitbase/init.go
@@ -362,7 +362,7 @@ func CommonMain(envPtr *string,
 
 		if (*rotateTokens || *tokenExpiration) && (*roleFileFilterPtr == "" || *tokenFileFilterPtr != "") {
 			getOrRevokeError := v.GetOrRevokeTokensInScope(namespaceTokenConfigs, *tokenFileFilterPtr, *tokenExpiration, logger)
-			if !*rotateTokens && getOrRevokeError != nil {
+			if getOrRevokeError != nil {
 				fmt.Println("Token revocation or access failure.  Cannot continue.")
 				os.Exit(-1)
 			}

--- a/pkg/vaulthelper/system/Vault.go
+++ b/pkg/vaulthelper/system/Vault.go
@@ -211,7 +211,7 @@ func (v *Vault) GetOrRevokeTokensInScope(dir string, tokenFilter string, tokenEx
 				}
 
 				if err != nil {
-					if response.StatusCode == 403 {
+					if response.StatusCode == 403 || response.StatusCode == 400 {
 						// Some accessors we don't have access to, but we don't care about those.
 						continue
 					} else {


### PR DESCRIPTION
If we can't access anything via an invalid accessor, just skip it.