### PR TITLE
Enable support for passing through env parameter into generated configs

### DIFF
--- a/pkg/cli/trcconfigbase/utils/templateHelper.go
+++ b/pkg/cli/trcconfigbase/utils/templateHelper.go
@@ -223,7 +223,7 @@ func PopulateTemplate(driverConfig *eUtils.DriverConfig,
 	} else {
 		rawFile, err := os.ReadFile(strings.Split(driverConfig.StartDir[0], coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir)+"_")[0] + coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir) + "_seeds/" + driverConfig.Env + "/" + driverConfig.Env + "_seed.yml")
 		if err != nil {
-			eUtils.LogErrorObject(&driverConfig.CoreConfig, errors.New("unable to open seed file for -novault: "+err.Error()), false)
+			eUtils.LogErrorObject(&driverConfig.CoreConfig, errors.New("unable to open seed file for -novault: " + err.Error()), false)
 		}
 
 		var rawYaml interface{}

--- a/pkg/cli/trcconfigbase/utils/templateHelper.go
+++ b/pkg/cli/trcconfigbase/utils/templateHelper.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/trimble-oss/tierceron/atrium/vestibulum/trcdb/opts/prod"
 	"github.com/trimble-oss/tierceron/buildopts/coreopts"
 	"github.com/trimble-oss/tierceron/pkg/core"
 	eUtils "github.com/trimble-oss/tierceron/pkg/utils"
@@ -350,6 +351,15 @@ func PopulateTemplate(driverConfig *eUtils.DriverConfig,
 					certData[2] = certSourcePath.(string)
 					return "", certData, nil
 				}
+			}
+		}
+
+		if !prod.IsProd() {
+			// Override trcenvparam if it was specified in original call
+			data, exists := values[filename].(map[string]interface{})
+			if exists {
+				data["trcenvparam"] = &driverConfig.Env
+				values[filename] = data
 			}
 		}
 

--- a/pkg/cli/trcconfigbase/utils/templateHelper.go
+++ b/pkg/cli/trcconfigbase/utils/templateHelper.go
@@ -355,10 +355,10 @@ func PopulateTemplate(driverConfig *eUtils.DriverConfig,
 		}
 
 		if !prod.IsProd() {
-			// Override trcenvparam if it was specified in original call
+			// Override trcEnvParam if it was specified in original call
 			data, exists := values[filename].(map[string]interface{})
 			if exists {
-				data["trcenvparam"] = &driverConfig.Env
+				data["trcEnvParam"] = &driverConfig.Env
 				values[filename] = data
 			}
 		}

--- a/pkg/cli/trcconfigbase/utils/templateHelper.go
+++ b/pkg/cli/trcconfigbase/utils/templateHelper.go
@@ -220,9 +220,9 @@ func PopulateTemplate(driverConfig *eUtils.DriverConfig,
 	if driverConfig.Token != "novault" {
 		cds.Init(&driverConfig.CoreConfig, modifier, secretMode, true, project, nil, service)
 	} else {
-		rawFile, err := os.ReadFile(strings.Split(driverConfig.StartDir[0], coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir)+"_")[0] + coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir) + "_seeds/" + driverConfig.EnvRaw + "/" + driverConfig.Env + "_seed.yml")
+		rawFile, err := os.ReadFile(strings.Split(driverConfig.StartDir[0], coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir)+"_")[0] + coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir) + "_seeds/" + driverConfig.Env + "/" + driverConfig.Env + "_seed.yml")
 		if err != nil {
-			eUtils.LogErrorObject(&driverConfig.CoreConfig, errors.New("unable to open seed file for -novault"), false)
+			eUtils.LogErrorObject(&driverConfig.CoreConfig, errors.New("unable to open seed file for -novault: "+err.Error()), false)
 		}
 
 		var rawYaml interface{}
@@ -293,7 +293,6 @@ func PopulateTemplate(driverConfig *eUtils.DriverConfig,
 							valueData[baseKey] = valueEntry
 						}
 					}
-
 				}
 			}
 		}
@@ -353,6 +352,7 @@ func PopulateTemplate(driverConfig *eUtils.DriverConfig,
 				}
 			}
 		}
+
 		err = t.Execute(&doc, values[filename])
 		str = doc.String()
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/trimble-oss/tierceron/issues/1090

This PR (limited functionality to non-prod environments for now) introduces a new environment parameter that can be used in trc templates called `trcEnvParam` to allow for generated configs to refer to the non-raw `driverConfig.Env` parameter.

Work Item [Here](https://dev.azure.com/ViewpointVSO/Spectrum/_workitems/edit/540913/)