### PR TITLE
Remove trc_seeds folder requirement if -dif flag is specified

### DIFF
--- a/pkg/cli/trcxbase/trcxbase.go
+++ b/pkg/cli/trcxbase/trcxbase.go
@@ -342,9 +342,11 @@ skipDiff:
 			fmt.Println("Missing required start template folder: " + *startDirPtr)
 			os.Exit(1)
 		}
-		if _, err := os.Stat(*endDirPtr); os.IsNotExist(err) {
-			fmt.Println("Missing required start seed folder: " + *endDirPtr)
-			os.Exit(1)
+		if !*diffPtr { // -diff doesn't require seed folder
+			if _, err := os.Stat(*endDirPtr); os.IsNotExist(err) {
+				fmt.Println("Missing required start seed folder: " + *endDirPtr)
+				os.Exit(1)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/trimble-oss/tierceron/issues/1084

- [x] Running `trcx -env=dev` without `trc_seeds` retains the `Missing required start seed folder: ./trc_seeds/` output
- [x] Running `trcx -env=dev,QA -diff` properly pulls and prints out their diffs without the `trc_seeds` folder present.