### PR TITLE
Add support for overriding templated cert destinations

### DIFF
--- a/pkg/cli/trcconfigbase/utils/templateHelper.go
+++ b/pkg/cli/trcconfigbase/utils/templateHelper.go
@@ -223,7 +223,7 @@ func PopulateTemplate(driverConfig *eUtils.DriverConfig,
 	} else {
 		rawFile, err := os.ReadFile(strings.Split(driverConfig.StartDir[0], coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir)+"_")[0] + coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir) + "_seeds/" + driverConfig.Env + "/" + driverConfig.Env + "_seed.yml")
 		if err != nil {
-			eUtils.LogErrorObject(&driverConfig.CoreConfig, errors.New("unable to open seed file for -novault: "+err.Error()), false)
+			eUtils.LogErrorObject(&driverConfig.CoreConfig, errors.New("unable to open seed file for -novault: " + err.Error()), false)
 		}
 
 		var rawYaml interface{}

--- a/pkg/cli/trcconfigbase/utils/templateHelper.go
+++ b/pkg/cli/trcconfigbase/utils/templateHelper.go
@@ -223,7 +223,7 @@ func PopulateTemplate(driverConfig *eUtils.DriverConfig,
 	} else {
 		rawFile, err := os.ReadFile(strings.Split(driverConfig.StartDir[0], coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir)+"_")[0] + coreopts.BuildOptions.GetFolderPrefix(driverConfig.StartDir) + "_seeds/" + driverConfig.Env + "/" + driverConfig.Env + "_seed.yml")
 		if err != nil {
-			eUtils.LogErrorObject(&driverConfig.CoreConfig, errors.New("unable to open seed file for -novault: " + err.Error()), false)
+			eUtils.LogErrorObject(&driverConfig.CoreConfig, errors.New("unable to open seed file for -novault: "+err.Error()), false)
 		}
 
 		var rawYaml interface{}
@@ -305,6 +305,10 @@ func PopulateTemplate(driverConfig *eUtils.DriverConfig,
 				certSourcePath, hasCertSourcePath := valueData["certSourcePath"]
 				certPasswordVaultPath, hasCertPasswordVaultPath := valueData["certPasswordVaultPath"]
 				certBundleJks, hasCertBundleJks := valueData["certBundleJks"]
+
+				if driverConfig.CertPathOverrides[filename] != "" {
+					certDestPath = driverConfig.CertPathOverrides[filename]
+				}
 
 				if hasCertDefinition && hasCertSourcePath {
 					if !ok {

--- a/pkg/utils/driverconfig.go
+++ b/pkg/utils/driverconfig.go
@@ -73,10 +73,11 @@ type DriverConfig struct {
 
 	SecretMode bool
 	// Tierceron source and destination I/O
-	StartDir       []string // Starting directory. possibly multiple
-	EndDir         string
-	OutputMemCache bool
-	MemFs          MemoryFileSystem
+	StartDir          []string // Starting directory. possibly multiple
+	EndDir            string
+	OutputMemCache    bool
+	MemFs             MemoryFileSystem
+	CertPathOverrides map[string]string // certFileName -> certDest
 
 	// Config modes....
 	ZeroConfig  bool


### PR DESCRIPTION
This PR allows trcconfig to override the templated cert files at runtime.

Example usage: `trcconfig -certs -certDestPath=foo:conf/bar.pfx`