### PR TITLE
Fix dereferencing nil EnvRaw pointer

### DIFF
--- a/atrium/vestibulum/trcshbase/trcsh.go
+++ b/atrium/vestibulum/trcshbase/trcsh.go
@@ -290,7 +290,11 @@ func CommonMain(envPtr *string, addrPtr *string, envCtxPtr *string,
 		ProcessDeploy(nil, config, "", "", *trcPathPtr, secretIDPtr, appRoleIDPtr, true)
 	} else {
 		//Replace dev-1 with DEPLOYMENTS-1
-		deploymentsKey := strings.Replace(*envPtr, c.EnvRaw, "DEPLOYMENTS", 1)
+		deploymentsKey := "DEPLOYMENTS"
+		subDeploymentIndex := strings.Index(*envPtr, "-")
+		if subDeploymentIndex != -1 {
+			deploymentsKey += (*envPtr)[subDeploymentIndex:]
+		}
 		deploymentsShard := os.Getenv(deploymentsKey)
 		agentToken := os.Getenv("AGENT_TOKEN")
 		agentEnv := os.Getenv("AGENT_ENV")


### PR DESCRIPTION
The [previous PR](https://github.com/trimble-oss/tierceron/pull/1099) introduced an issue when starting the TrcDeploy service:

```sh
Cert read failure.
trcsh Version: 1.26
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x60 pc=0x21e20f5]

goroutine 1 [running]:
github.com/trimble-oss/tierceron/atrium/vestibulum/trcshbase.CommonMain(0xc000176990, 0x9?, 0x0?, 0x0?, 0x278acf6?, 0x12?, {0xc0000a6440, 0x2, 0x2}, 0x0)
        /home/azuredeploy/myagent/_work/1/s/pkg/mod/github.com/trimble-oss/tierceron/atrium@v0.0.0-20240621201024-129e22937bdf/vestibulum/trcshbase/trcsh.go:293 +0x315
main.main()
        /home/azuredeploy/myagent/_work/1/s/pendentive/atrium/vestibulum/shell/trcsh/trcsh.go:56 +0x565
```

This PR aims to fix this error, relying solely on the envPtr and _simpler_ string manipulation logic.