### PR TITLE
Dont require pluginNamePtr to be present

### DIFF
--- a/pkg/core/util/repository/azrcr.go
+++ b/pkg/core/util/repository/azrcr.go
@@ -330,9 +330,5 @@ func ValidateRepository(driverConfig *eUtils.DriverConfig, pluginToolConfig map[
 		return errors.New("malformed acr repository - https:// required")
 	}
 
-	if val, ok := pluginToolConfig["pluginNamePtr"]; !ok || len(val.(string)) == 0 {
-		driverConfig.CoreConfig.Log.Printf("pluginNamePtr undefined.  Refusing to continue.\n")
-		return errors.New("undefined pluginNamePtr")
-	}
 	return nil
 }


### PR DESCRIPTION
This PR removes an unnecessary check (that, in fact, causes issues when deploying code) of the `pluginNamePtr` upon attempts to use the azure repository.

In terms of behavior, this ValidateRepository should not care about the `pluginNamePtr`, as it is intended to verify the security (https) and presence (non-nil) of the repository URL.

Additionally, the entry-point for this code already verifies that pluginNamePtr is defined (for functions where it is needed, see [here](https://github.com/trimble-oss/tierceron/blob/main/atrium/vestibulum/trcdb/trcplgtoolbase/trcplgtoolbase.go#L166)).