### PR TITLE
DynamicReloader fix.  Also general cleanup

### DIFF
--- a/pkg/core/util/hive/kernelcr.go
+++ b/pkg/core/util/hive/kernelcr.go
@@ -221,6 +221,7 @@ func (pluginHandler *PluginHandler) DynamicReloader(driverConfig *config.DriverC
 				if t, ok := metadata["created_time"]; ok {
 					if t != v.CreatedTime {
 						// validate cert and restart kernel
+						driverConfig.CoreConfig.Log.Printf("Cert mismatch detected for %s - calling LoadCertComponent\n", k)
 						configuredCert, err := certutil.LoadCertComponent(driverConfig,
 							mod,
 							k)
@@ -250,6 +251,8 @@ func (pluginHandler *PluginHandler) DynamicReloader(driverConfig *config.DriverC
 							if certSha256 != v.sha256 {
 								if pluginHandler.Services == nil {
 									driverConfig.CoreConfig.Log.Println("Services map is nil, cannot iterate for cert reload")
+									v.CreatedTime = t
+									globalCertCache.Set(k, v)
 									goto waitToReload
 								}
 								for s, sPluginHandler := range *pluginHandler.Services {
@@ -271,6 +274,9 @@ func (pluginHandler *PluginHandler) DynamicReloader(driverConfig *config.DriverC
 								// 2. Start each plugin
 								eUtils.LogSyncAndExit(driverConfig.CoreConfig.Log, "Shutting down kernel...", 0)
 							} else {
+								v.CreatedTime = t
+								globalCertCache.Set(k, v)
+								driverConfig.CoreConfig.Log.Printf("Cert %s validated, updating cached CreatedTime to %v\n", k, t)
 								continue
 							}
 						} else {

--- a/pkg/utils/indexedFlagUtil.go
+++ b/pkg/utils/indexedFlagUtil.go
@@ -60,7 +60,7 @@ func CheckInitFlags(flagset *flag.FlagSet, arguments []string) error {
 	}
 
 	// Cannot specify a pathed indexed/restricted seed file while specifying a restricted/indexed section.
-	if len(*IndexNameFilterPtr) > 0 || len(*ServiceNameFilterPtr) > 0 || len(*IndexValueFilterPtr) > 0 || len(*ServiceNameFilterPtr) > 0 {
+	if len(*IndexNameFilterPtr) > 0 || len(*IndexValueFilterPtr) > 0 || len(*ServiceNameFilterPtr) > 0 {
 		filtered = true
 	}
 	if len(*RestrictedPtr) > 0 && len(*IndexedPtr) > 0 && filtered {
@@ -96,7 +96,7 @@ func CheckInitFlags(flagset *flag.FlagSet, arguments []string) error {
 	}
 
 	// These two filters are used differently between x and init so this is modifying incoming params to what is expected inside shared helpers.
-	if len(*IndexValueFilterPtr) > 0 && len(*ServiceNameFilterPtr) == 0 && len(*ServiceNameFilterPtr) == 0 {
+	if len(*IndexValueFilterPtr) > 0 && len(*ServiceNameFilterPtr) == 0 {
 		*ServiceNameFilterPtr = *IndexValueFilterPtr
 		*IndexValueFilterPtr = ""
 	}

--- a/pkg/utils/vaultUtil.go
+++ b/pkg/utils/vaultUtil.go
@@ -54,28 +54,6 @@ func isRetryable(err error) bool {
 	return false
 }
 
-// isTimout detects if the err is a timeout.
-// Deprecated: Use isRetryable instead for more comprehensive error handling.
-func isTimeout(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return true
-	}
-
-	if errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
-
-	errStr := err.Error()
-	return strings.Contains(errStr, "timeout") ||
-		strings.Contains(errStr, "timed out") ||
-		strings.Contains(errStr, "deadline exceeded")
-}
-
 // InitVaultMod helps to easily initialize a vault and a modifier all at once.
 func InitVaultMod(driverConfig *config.DriverConfig) (*config.DriverConfig, *helperkv.Modifier, *sys.Vault, error) {
 	if driverConfig == nil {


### PR DESCRIPTION
If vault metadata reports a new record, but the contents of that record haven't changed, we should still update the cert time to prevent endless rechecks.